### PR TITLE
Fix null conversion bug

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -98,6 +98,8 @@ export function jsonToYType<T>(object: T): JsonToYType<T> {
     const yArray = new YArray();
     object.forEach((value) => yArray.push([jsonToYType(value)]));
     return yArray as JsonToYType<T>;
+  } else if (object === null) {
+    return null as unknown as JsonToYType<T>;
   } else if (typeof object === "object") {
     const map = new YMap();
     for (const key in object) {

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -429,4 +429,27 @@ describe('Yjs and jsondiffpatch integration tests', () => {
     expect(rightIndexes).toEqual([1, 3, 4, 7]);
   });
 
+  test('Null value synchronization', () => {
+    ydoc.transact(() => {
+      yMap.set('maybe', null);
+    });
+
+    expect(plainObject).toEqual({
+      maybe: null,
+    });
+
+    const newPlainObject = {
+      maybe: 1,
+    };
+
+    ydoc.transact(() => {
+      applyJsonDiffToYjs(plainObject, newPlainObject, yMap);
+    });
+
+    expect(yMap.get('maybe')).toBe(1);
+    expect(plainObject).toEqual({
+      maybe: 1,
+    });
+  });
+
 });


### PR DESCRIPTION
## Summary
- handle `null` in `jsonToYType` so that null values aren't lost
- add regression test for null handling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684e0f9c4bb883259c0d67811850db96